### PR TITLE
Atom feed

### DIFF
--- a/app/concepts/videos/cells/video/feed.slim
+++ b/app/concepts/videos/cells/video/feed.slim
@@ -1,0 +1,11 @@
+entry
+  id= show_url
+  link href= show_url
+  title= title
+  updated= updated_formatted
+  author
+    name= presenter_name
+
+  content type='html'
+    = embed_code.html_safe
+    = description

--- a/app/concepts/videos/cells/video/feed.slim
+++ b/app/concepts/videos/cells/video/feed.slim
@@ -6,6 +6,6 @@ entry
   author
     name= presenter_name
 
-  content type='html'
+  content type="html"
     = embed_code.html_safe
     = description

--- a/app/concepts/videos/cells/video_cell.rb
+++ b/app/concepts/videos/cells/video_cell.rb
@@ -13,6 +13,10 @@ module Videos
         render
       end
 
+      def feed
+        render
+      end
+
       def show
         render
       end
@@ -34,12 +38,20 @@ module Videos
         link_to model.presenter.name, presenter_path(model.presenter)
       end
 
+      def updated_formatted
+        model.updated_at.iso8601
+      end
+
       def show_link
         link_to title, show_path
       end
 
       def show_path
         video_path(model.to_param)
+      end
+
+      def show_url
+        video_url(model.to_param)
       end
 
       def edit_link

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -3,6 +3,11 @@ class VideosController < ApplicationController
 
   def index
     @videos = Video.list_for(current_user).page(params[:page])
+
+    respond_to do |format|
+      format.html
+      format.atom { render layout: false }
+    end
   end
 
   def show

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -6,7 +6,7 @@ class VideosController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.atom { render layout: false }
+      format.atom { render :layout => false }
     end
   end
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -48,6 +48,8 @@ html lang="en"
                 i.fa.fa-twitter.twitter-footer.wow.bounce data-wow-delay="0.2s"
               a href="https://github.com/andypike/ruby_videos" target="_blank"
                 i.fa.fa-github.github-footer.wow.bounce data-wow-delay="0.2s"
+              = link_to videos_url(format: :atom), target: :blank do
+                i.fa.fa-rss.rss-footer.wow.bounce data-wow-delay="0.2s"
     .bg-footer-bottom
       .container
         .row-footer-bottom.row

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,7 +14,7 @@ html lang="en"
     = stylesheet_link_tag    "http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,600,700,300,800"
     = javascript_include_tag "application"
     = csrf_meta_tags
-    = auto_discovery_link_tag(:rss, videos_url(format: :atom))
+    = auto_discovery_link_tag(:rss, videos_url(:format => :atom))
     = analytics_init if Rails.env.production?
 
     /![if lt IE 9]
@@ -48,7 +48,7 @@ html lang="en"
                 i.fa.fa-twitter.twitter-footer.wow.bounce data-wow-delay="0.2s"
               a href="https://github.com/andypike/ruby_videos" target="_blank"
                 i.fa.fa-github.github-footer.wow.bounce data-wow-delay="0.2s"
-              = link_to videos_url(format: :atom), target: :blank do
+              = link_to videos_url(:format => :atom), :target => :blank do
                 i.fa.fa-rss.rss-footer.wow.bounce data-wow-delay="0.2s"
     .bg-footer-bottom
       .container

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -14,6 +14,7 @@ html lang="en"
     = stylesheet_link_tag    "http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,600,700,300,800"
     = javascript_include_tag "application"
     = csrf_meta_tags
+    = auto_discovery_link_tag(:rss, videos_url(format: :atom))
     = analytics_init if Rails.env.production?
 
     /![if lt IE 9]

--- a/app/views/videos/index.atom.slim
+++ b/app/views/videos/index.atom.slim
@@ -1,0 +1,15 @@
+doctype xml
+feed xmlns='http://www.w3.org/2005/Atom'
+
+  title Ruby Videos
+  id = root_url
+  link href=root_url
+  link rel='self' type='application/atom+xml' href=videos_url(format: :atom)
+  updated= @videos.maximum(:updated_at).iso8601
+  icon= image_url('logo.png')
+  logo= image_url('logo.png')
+  category term="programming"
+
+  = cell("videos/cells/video",
+    collection: @videos,
+    method: :feed)

--- a/app/views/videos/index.atom.slim
+++ b/app/views/videos/index.atom.slim
@@ -2,7 +2,7 @@ doctype xml
 feed xmlns="http://www.w3.org/2005/Atom"
 
   title Ruby Videos
-  id = root_url
+  id= root_url
   link href=root_url
   link rel="self" type="application/atom+xml" href=videos_url(:format => :atom)
   updated= @videos.maximum(:updated_at).iso8601

--- a/app/views/videos/index.atom.slim
+++ b/app/views/videos/index.atom.slim
@@ -1,15 +1,15 @@
 doctype xml
-feed xmlns='http://www.w3.org/2005/Atom'
+feed xmlns="http://www.w3.org/2005/Atom"
 
   title Ruby Videos
   id = root_url
   link href=root_url
-  link rel='self' type='application/atom+xml' href=videos_url(format: :atom)
+  link rel="self" type="application/atom+xml" href=videos_url(:format => :atom)
   updated= @videos.maximum(:updated_at).iso8601
-  icon= image_url('logo.png')
-  logo= image_url('logo.png')
+  icon= image_url("logo.png")
+  logo= image_url("logo.png")
   category term="programming"
 
   = cell("videos/cells/video",
     collection: @videos,
-    method: :feed)
+    :method => :feed)

--- a/app/views/videos/index.atom.slim
+++ b/app/views/videos/index.atom.slim
@@ -11,5 +11,5 @@ feed xmlns="http://www.w3.org/2005/Atom"
   category term="programming"
 
   = cell("videos/cells/video",
-    collection: @videos,
+    :collection => @videos,
     :method => :feed)

--- a/spec/requests/videos_feed_spec.rb
+++ b/spec/requests/videos_feed_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
-RSpec.describe "Videos Feed", :type => :request do
+RSpec.describe "Videos Feed" do
 
   let!(:video) do
     create(:published_video,
-           :updated_at => DateTime.new(2015, 6, 9))
+      :updated_at => DateTime.new(2015, 6, 9))
   end
 
   before do
-    get videos_path, format: :atom
+    get videos_path, :format => :atom
   end
 
   let(:feed) { Hash.from_xml(response.body)["feed"] }

--- a/spec/requests/videos_feed_spec.rb
+++ b/spec/requests/videos_feed_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Videos Feed", :type => :request do
+
+  let!(:video) do
+    create(:published_video,
+           :updated_at => DateTime.new(2015, 6, 9))
+  end
+
+  before do
+    get videos_path, format: :atom
+  end
+
+  let(:feed) { Hash.from_xml(response.body)["feed"] }
+  let(:entry) { feed["entry"] }
+
+  it "returns valid atom feed" do
+    expect(feed["id"]).to eq(root_url)
+    expect(feed["title"]).to eq("Ruby Videos")
+    expect(feed["updated"]).to match(/2015-06-09/)
+  end
+
+  it "returns feed containing valid entry" do
+    expect(entry["id"]).to eq(video_url(video))
+    expect(entry["title"]).to eq(video.title)
+    expect(entry["updated"]).to match(/2015-06-09/)
+  end
+
+end

--- a/spec/requests/videos_feed_spec.rb
+++ b/spec/requests/videos_feed_spec.rb
@@ -17,13 +17,13 @@ RSpec.describe "Videos Feed", :type => :request do
   it "returns valid atom feed" do
     expect(feed["id"]).to eq(root_url)
     expect(feed["title"]).to eq("Ruby Videos")
-    expect(feed["updated"]).to match(/2015-06-09/)
+    expect(feed["updated"]).to match(/2015-06-09.*00Z/)
   end
 
   it "returns feed containing valid entry" do
     expect(entry["id"]).to eq(video_url(video))
     expect(entry["title"]).to eq(video.title)
-    expect(entry["updated"]).to match(/2015-06-09/)
+    expect(entry["updated"]).to match(/2015-06-09.*00Z/)
   end
 
 end


### PR DESCRIPTION
Hey Andy,

This should resolve issue #50 

It adds a new atom feed for the videos page and includes an auto discovery link in the layout so people can just paste the url http://rubyvideos.com and the feed readers should pick up the feed url correctly. I've also added a link to the feed in the footer next to the social icons to advertise the fact that a feed is available.

I wasn't 100% sure on the content so decided to add the embedded video and full description so as to give most value directly in the feed, you ok with this or would you rather it was a teaser and the visitors would come to the site to view the video?

I've tested this in Feedly and seemed to render very nicely.

The experimental style of the project and some of the choices like cells gem and slim are new to me so have a look and see if you think I've managed to keep to the style of the project.

Let me know what you think,
.FxN
