### PR TITLE
Clean up specs that verify commands pubish events

### DIFF
--- a/spec/concepts/authentication/login_with_omni_auth_spec.rb
+++ b/spec/concepts/authentication/login_with_omni_auth_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Authentication::LoginWithOmniAuth do
-  let(:listener) { double.as_null_object }
+  let(:listener) { spy }
   let(:valid_info) do
     instance_double("Authentication::OmniAuthInfo",
       :provider  => "github",

--- a/spec/concepts/presenters/create_spec.rb
+++ b/spec/concepts/presenters/create_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Presenters::Create do
-  let(:listener)  { double.as_null_object }
+  let(:listener)  { spy }
   let(:presenter) { Presenter.first }
   let(:form)      { Presenters::Form.build_from(:presenter, params) }
   let(:params) do

--- a/spec/concepts/presenters/update_spec.rb
+++ b/spec/concepts/presenters/update_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Presenters::Update do
-  let(:listener)  { double.as_null_object }
+  let(:listener)  { spy }
   let(:presenter) { create(:presenter, :name => "Bob Smith") }
   let(:form)      { Presenters::Form.build_from(:presenter, params) }
   let(:params) do

--- a/spec/concepts/videos/create_spec.rb
+++ b/spec/concepts/videos/create_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Videos::Create do
-  let(:listener)  { double.as_null_object }
+  let(:listener)  { spy }
   let(:video)     { Video.first }
   let(:form)      { Videos::Form.build_from(:video, params) }
   let(:user)      { create(:user) }

--- a/spec/concepts/videos/create_suggestion_spec.rb
+++ b/spec/concepts/videos/create_suggestion_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Videos::CreateSuggestion, :async => true do
-  let(:listener) { double.as_null_object }
+  let(:listener) { spy }
   let(:video)    { Video.first }
   let(:form)     { Videos::SuggestionForm.build_from(:suggestion, params) }
   let(:user)     { create(:user) }

--- a/spec/concepts/videos/update_spec.rb
+++ b/spec/concepts/videos/update_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Videos::Update do
-  let(:listener) { double.as_null_object }
+  let(:listener) { spy }
   let(:video)    { create(:video, :title => "All the little things") }
   let(:form)     { Videos::Form.build_from(:video, params) }
   let(:params) do


### PR DESCRIPTION
Uses an RSpec spy rather than a null double.
