### PR TITLE
Refactor responsibilities of how a user session is managed

### DIFF
--- a/app/concepts/authentication/login_with_omni_auth.rb
+++ b/app/concepts/authentication/login_with_omni_auth.rb
@@ -2,15 +2,18 @@ module Authentication
   class LoginWithOmniAuth
     include Wisper::Publisher
 
-    attr_reader :info
+    attr_reader :info, :warden
 
-    def initialize(info)
+    def initialize(info, warden)
       @info = info
+      @warden = warden
     end
 
     def call
       if info.valid?
         user = find_or_create_user
+        warden.login(user)
+
         publish(:ok, user)
       else
         publish(:fail)

--- a/app/concepts/authentication/warden.rb
+++ b/app/concepts/authentication/warden.rb
@@ -1,0 +1,31 @@
+module Authentication
+  class Warden
+    attr_reader :store
+
+    def initialize(store)
+      @store = store
+    end
+
+    def current_user
+      User.find_by(:id => user_id) || GuestUser.new
+    end
+
+    def login(user)
+      self.current_user = user
+    end
+
+    def logout
+      self.current_user = GuestUser.new
+    end
+
+    private
+
+    def current_user=(user)
+      store[:user_id] = user.id
+    end
+
+    def user_id
+      store[:user_id]
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,21 +2,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery :with => :exception
   helper_method :current_user
 
-  CURRENT_USER_KEY = :user_id
-
   def current_user
-    if session[CURRENT_USER_KEY].present?
-      @current_user ||= User.find_by(:id => session[CURRENT_USER_KEY])
-    end
-
-    @current_user || GuestUser.new
+    @current_user ||= warden.current_user
   end
 
   private
 
-  def set_current_user(user, notice)
-    session[CURRENT_USER_KEY] = user.id
-    redirect_to root_path, :notice => t(notice)
+  def warden
+    @warden ||= Authentication::Warden.new(session)
   end
 
   def ensure_admin

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,13 +2,14 @@ class SessionsController < ApplicationController
   def create
     info = Authentication::OmniAuthInfo.new(env["omniauth.auth"])
 
-    Authentication::LoginWithOmniAuth.new(info)
-      .on(:ok)   { |user| set_current_user(user, :login_success) }
+    Authentication::LoginWithOmniAuth.new(info, warden)
+      .on(:ok)   { redirect_to root_path, :notice => t(:login_success) }
       .on(:fail) { redirect_to root_path, :alert => t(:login_fail) }
       .call
   end
 
   def destroy
-    set_current_user(GuestUser.new, :logout_success)
+    warden.logout
+    redirect_to root_path, :notice => t(:logout_success)
   end
 end

--- a/spec/concepts/authentication/warden_spec.rb
+++ b/spec/concepts/authentication/warden_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Authentication::Warden do
+  let(:store) { {} }
+
+  subject { Authentication::Warden.new(store) }
+
+  describe "#login" do
+    it "adds the user id in the given store" do
+      subject.login(User.new(:id => 1))
+
+      expect(store[:user_id]).to eq(1)
+    end
+  end
+
+  describe "#logout" do
+    it "clears out the user id in the given store" do
+      subject.logout
+
+      expect(store[:user_id]).to eq(:guest)
+    end
+  end
+
+  describe "#current_user" do
+    context "nobody is logged in" do
+      it "returns an unauthenticated user" do
+        expect(subject.current_user).not_to be_authenticated
+      end
+    end
+
+    context "a user is logged in" do
+      it "returns the authenticated user" do
+        user = create(:user)
+        store[:user_id] = user.id
+
+        expect(subject.current_user).to eq(user)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I wanted to refactor logging in, logging out and getting the current user. Previously all of this was in the `ApplicationController` and it felt a bit messy. Also I wanted the logging in to be part of the `LoginWithOmniAuth` command. 

First thing I did was to extract out the current user related code from the `ApplicationController` and put it in the new `Authentication::Warden` class. I struggled with a name for this but the dictionary definition is _"a person responsible for the supervision of a particular place or activity or for enforcing the regulations associated with it"_, I also considered `Guard`, `Bouncer` and some others but this felt ok for now. The warden is passed a "store" so it can set and get the id of the current user. As this is a web app, we just pass in the session, but this could be any object that responds to `[]` and `[]=`.

After that, I passed in the warden to the `LoginWithOmniAuth` which would allow it to log the user in after authentication was successful.
